### PR TITLE
Literate Analysis in R markdown challenge fix

### DIFF
--- a/materials/sections/r-introduction-to-rmarkdown.Rmd
+++ b/materials/sections/r-introduction-to-rmarkdown.Rmd
@@ -243,7 +243,7 @@ If you run this line in your RMarkdown document, you should see the `bg_chem` ob
 Use one of two methods to figure out how to suppress **warning** and **message** text in your chunk output:
 
 1.  The gear icon in the chunk, next to the play button
-2.  The [RMarkdown quick reference](https://rstudio.com/wp-content/uploads/2015/03/rmarkdown-reference.pdf)
+2.  The [RMarkdown reference guide](https://rstudio.com/wp-content/uploads/2015/03/rmarkdown-reference.pdf)
 
 #### Aside {.unnumbered .aside}
 

--- a/materials/sections/r-introduction-to-rmarkdown.Rmd
+++ b/materials/sections/r-introduction-to-rmarkdown.Rmd
@@ -243,7 +243,7 @@ If you run this line in your RMarkdown document, you should see the `bg_chem` ob
 Use one of two methods to figure out how to suppress **warning** and **message** text in your chunk output:
 
 1.  The gear icon in the chunk, next to the play button
-2.  The [RMarkdown reference guide](https://rstudio.com/wp-content/uploads/2015/03/rmarkdown-reference.pdf)
+2.  The [RMarkdown reference guide](https://rstudio.com/wp-content/uploads/2015/03/rmarkdown-reference.pdf) (also under Help > Cheatsheets)
 
 #### Aside {.unnumbered .aside}
 


### PR DESCRIPTION
Fix the [suppress warning and message challenge](https://learning.nceas.ucsb.edu/2021-07-RRCourse/session-3-literate-analysis-with-rmarkdown.html#challenge-3) so that it refers people to the [Reference guide](https://learning.nceas.ucsb.edu/2021-07-RRCourse/session-3-literate-analysis-with-rmarkdown.html#challenge-3) rather than the RMarkdown quick reference so even if you don't click the link you will go to the right document.